### PR TITLE
Fixes #8 - Underscored filenames

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -16,7 +16,7 @@ module.exports = function(grunt) {
 
     gulp: {
       concat: function() {
-        return gulp.src(globalConfig.src + '/**/*.*')
+        return gulp.src(globalConfig.src + '/**/[^_]*.*')
           .pipe(cssimport())
           .pipe(gulp.dest('assets/'));
       }


### PR DESCRIPTION
- Don't run CSSImport on `_*.*` filenames.
- Don't move `_*.*` filenames to assets.

Fixes #8 