### PR TITLE
making sure only theme.scss.liquid is copied over

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,9 +8,9 @@ var globalConfig = {
 
 // Process CSS
 gulp.task('styles', function(){
-  return gulp.src(globalConfig.src + '/**/*.*')
+  return gulp.src(globalConfig.src + '/theme.scss.liquid')
     .pipe(cssimport())
-    .pipe(gulp.dest('assets/'));
+    .pipe(gulp.dest('./assets/theme.scss.liquid'));
 })
 
 // Watch files


### PR DESCRIPTION
This will ensure that only `theme.scss.liquid` is read and copied over to `assets/`.

[This solution](https://github.com/Shopify/shopify-css-import/pull/15) probably works too but I feel that directly reading `theme.scss.liquid` worked best for me. 
