### PR TITLE
Add deprecation announcement

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+## Deprecation warning ⚠️
+
+Instead of these one-off grunt/gulp build tasks, developers are encouraged to check out [Slate](https://github.com/Shopify/slate) -
+a theme scaffolding and command line tool built for developing Shopify themes.
+
+You can continue to use these tasks; however, this repo will not be kept up-to-date with changes in Shopify theme development.
+
+---
+
 Adding CSS @import to theme development
 =====================
 


### PR DESCRIPTION
Not much use for this repo anymore now that [Slate is public](https://github.com/Shopify/slate).

cc @m-ux @chrisberthe @t-kelly 